### PR TITLE
Use log4j2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -311,3 +311,30 @@ __pycache__/
 **/.idea/caches/build_file_checksums.ser
 
 **/target
+
+Ignored
+*.jar
+*.jardesc
+/Java/Doc
+
+.settings
+.classpath
+.project
+
+# =============
+# Maven entries
+# =============
+
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+
+# Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
+!/.mvn/wrapper/maven-wrapper.jar
+/Java/*.jardesc

--- a/Java/RelativityClient/pom.xml
+++ b/Java/RelativityClient/pom.xml
@@ -49,8 +49,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <nuix-workstation-lib>C:/Program Files/Nuix/Nuix 8.0/lib</nuix-workstation-lib>
-        <scripting-version>8.0.3.121</scripting-version>
+        <nuix-workstation-lib>C:/Program Files/Nuix/Nuix 8.6/lib</nuix-workstation-lib>
+        <scripting-version>8.6.2.414</scripting-version>
     </properties>
 
     <dependencies>
@@ -83,12 +83,16 @@
             <version>3.7.4</version>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/log4j/log4j -->
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-        </dependency>
+		<dependency>
+		  <groupId>org.apache.logging.log4j</groupId>
+		  <artifactId>log4j-api</artifactId>
+		  <version>2.13.3</version>
+		</dependency>
+		<dependency>
+		  <groupId>org.apache.logging.log4j</groupId>
+		  <artifactId>log4j-core</artifactId>
+		  <version>2.13.3</version>
+		</dependency>
 
         <!-- https://mvnrepository.com/artifact/joda-time/joda-time -->
         <dependency>
@@ -104,7 +108,6 @@
             <version>${scripting-version}</version>
             <systemPath>${nuix-workstation-lib}/nuix-scripting-api-${scripting-version}.jar</systemPath>
         </dependency>
-
     </dependencies>
 
 </project>

--- a/Java/RelativityClient/src/main/java/com/nuix/relativityclient/HeadlessRelativityClient.java
+++ b/Java/RelativityClient/src/main/java/com/nuix/relativityclient/HeadlessRelativityClient.java
@@ -12,8 +12,6 @@ import nuix.Case;
 import nuix.MetadataProfile;
 import nuix.ProductionSet;
 import nuix.Utilities;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
@@ -22,6 +20,9 @@ import java.io.StringWriter;
 import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class HeadlessRelativityClient {
 

--- a/Java/RelativityClient/src/main/java/com/nuix/relativityclient/RelativityClientUI.java
+++ b/Java/RelativityClient/src/main/java/com/nuix/relativityclient/RelativityClientUI.java
@@ -6,8 +6,8 @@ import com.nuix.relativityclient.ui.relativitymapping.RelativityMappingFrame;
 import com.nuix.relativityclient.ui.settingsframe.SettingsFrame;
 import nuix.Case;
 import nuix.Utilities;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.awt.*;
 import java.awt.event.WindowAdapter;

--- a/Java/RelativityClient/src/main/java/com/nuix/relativityclient/clients/RelativityJdbcUploadClient.java
+++ b/Java/RelativityClient/src/main/java/com/nuix/relativityclient/clients/RelativityJdbcUploadClient.java
@@ -8,8 +8,8 @@ import com.nuix.relativityclient.relativitytypes.FieldColumn;
 import com.nuix.relativityclient.utils.ApplicationLogger;
 import com.nuix.relativityclient.utils.JdbcClient;
 import nuix.*;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/Java/RelativityClient/src/main/java/com/nuix/relativityclient/clients/RelativityLoadfileUploadClient.java
+++ b/Java/RelativityClient/src/main/java/com/nuix/relativityclient/clients/RelativityLoadfileUploadClient.java
@@ -2,8 +2,8 @@ package com.nuix.relativityclient.clients;
 
 import com.nuix.relativityclient.model.ClientLauncherSettings;
 import com.nuix.relativityclient.utils.ApplicationLogger;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/Java/RelativityClient/src/main/java/com/nuix/relativityclient/model/FieldsSettings.java
+++ b/Java/RelativityClient/src/main/java/com/nuix/relativityclient/model/FieldsSettings.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.nuix.relativityclient.relativitytypes.Field;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.*;
 import java.util.stream.Collectors;

--- a/Java/RelativityClient/src/main/java/com/nuix/relativityclient/model/ModuleSettings.java
+++ b/Java/RelativityClient/src/main/java/com/nuix/relativityclient/model/ModuleSettings.java
@@ -10,8 +10,8 @@ import com.nuix.relativityclient.relativitytypes.Field;
 import com.nuix.relativityclient.relativitytypes.Folder;
 import com.nuix.relativityclient.relativitytypes.Workspace;
 import nuix.*;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.*;
 import java.util.stream.Collectors;

--- a/Java/RelativityClient/src/main/java/com/nuix/relativityclient/ui/NotificationDialogs.java
+++ b/Java/RelativityClient/src/main/java/com/nuix/relativityclient/ui/NotificationDialogs.java
@@ -1,6 +1,6 @@
 package com.nuix.relativityclient.ui;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
 
 import javax.swing.*;
 import java.awt.*;

--- a/Java/RelativityClient/src/main/java/com/nuix/relativityclient/ui/logframe/LogFrame.java
+++ b/Java/RelativityClient/src/main/java/com/nuix/relativityclient/ui/logframe/LogFrame.java
@@ -7,8 +7,8 @@ package com.nuix.relativityclient.ui.logframe;
 import com.nuix.relativityclient.ui.NotificationDialogs;
 import com.nuix.relativityclient.ui.settingsframe.SettingsFrame;
 import net.miginfocom.swing.MigLayout;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.swing.*;
 import javax.swing.text.*;

--- a/Java/RelativityClient/src/main/java/com/nuix/relativityclient/ui/logframe/LogFrameApplicationLogger.java
+++ b/Java/RelativityClient/src/main/java/com/nuix/relativityclient/ui/logframe/LogFrameApplicationLogger.java
@@ -2,8 +2,8 @@ package com.nuix.relativityclient.ui.logframe;
 
 import com.nuix.relativityclient.ui.NotificationDialogs;
 import com.nuix.relativityclient.utils.ApplicationLogger;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.swing.*;
 import javax.swing.text.*;

--- a/Java/RelativityClient/src/main/java/com/nuix/relativityclient/ui/relativitymapping/RelativityMappingFrame.java
+++ b/Java/RelativityClient/src/main/java/com/nuix/relativityclient/ui/relativitymapping/RelativityMappingFrame.java
@@ -25,8 +25,8 @@ import com.nuix.relativityclient.ui.cellrenderers.FieldMappingCellRenderer;
 import net.miginfocom.swing.MigLayout;
 import nuix.Case;
 import nuix.Utilities;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.swing.*;
 import javax.swing.border.TitledBorder;

--- a/Java/RelativityClient/src/main/java/com/nuix/relativityclient/ui/settingsframe/SettingsFrame.java
+++ b/Java/RelativityClient/src/main/java/com/nuix/relativityclient/ui/settingsframe/SettingsFrame.java
@@ -32,8 +32,8 @@ import nuix.Case;
 import nuix.MetadataProfile;
 import nuix.ProductionSet;
 import nuix.Utilities;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import umich.ms.batmass.gui.core.api.util.glasspane.DisabledPanel;
 
 import javax.swing.*;

--- a/Java/RelativityClient/src/main/java/com/nuix/relativityclient/utils/ApplicationLogger.java
+++ b/Java/RelativityClient/src/main/java/com/nuix/relativityclient/utils/ApplicationLogger.java
@@ -1,7 +1,7 @@
 package com.nuix.relativityclient.utils;
 
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.joda.time.DateTime;
 
 import java.util.HashSet;

--- a/Java/RelativityClient/src/main/java/com/nuix/relativityclient/utils/JdbcClient.java
+++ b/Java/RelativityClient/src/main/java/com/nuix/relativityclient/utils/JdbcClient.java
@@ -1,8 +1,8 @@
 package com.nuix.relativityclient.utils;
 
 import com.nuix.relativityclient.relativitytypes.FieldColumn;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.sql.Date;
 import java.sql.*;

--- a/Java/RelativityClient/src/main/java/com/nuix/relativityclient/utils/RelativityRestClient.java
+++ b/Java/RelativityClient/src/main/java/com/nuix/relativityclient/utils/RelativityRestClient.java
@@ -1,8 +1,8 @@
 package com.nuix.relativityclient.utils;
 
 import com.nuix.relativityclient.relativitytypes.*;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.client.Client;

--- a/Java/RelativityClient/src/main/java/com/nuix/relativityclient/utils/TaskDelegator.java
+++ b/Java/RelativityClient/src/main/java/com/nuix/relativityclient/utils/TaskDelegator.java
@@ -1,7 +1,7 @@
 package com.nuix.relativityclient.utils;
 
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.concurrent.*;
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 Nuix Relativity Connector
 ===============================
 
-![This script was last tested in Nuix 8.0](https://img.shields.io/badge/Script%20Tested%20in%20Nuix-8.0-green.svg)
-
 View the GitHub project [here](https://github.com/Nuix/Nuix-Relativity-Connector).
 
 # Overview
@@ -32,9 +30,9 @@ The following modules can be used for the Direct SQL and File Share Upload scena
 #### Java User Interface
 - Download and install the [Java Development Kit](https://www.oracle.com/technetwork/java/javase/downloads/index.html)
 - Download and install [Apache Maven](https://maven.apache.org/download.cgi)
-- The Maven `pom.xml` file for the Java User Interface references Nuix Workstation 8.0.3.121. If using a different version of Nuix Workstation when building the Java User Interface, modify the file `Java\RelativityClientUserInterface\pom.xml` and update the property `scripting-version` to reflect the version of Nuix Workstation installed.
-- In the `Java\RelativityClientUserInterface` folder from this repository, build the Java User Interface by running the command `mvn package`.
-- Copy the resulting file `Java\RelativityClientUserInterface\target\relativity-client-1.0.jar` to `JavaScript\RelativityClient.nuixscript`
+- The Maven `pom.xml` file for the Java User Interface references Nuix Workstation 8.6.2.414. If using a different version of Nuix Workstation when building the Java User Interface, modify the file `Java\RelativityClient\pom.xml` and update the property `scripting-version` to reflect the version of Nuix Workstation installed.
+- In the `Java\RelativityClient` folder from this repository, build the Java User Interface by running the command `mvn package`.
+- Copy the resulting file `Java\RelativityClient\target\relativity-client-1.0.jar` to `JavaScript\RelativityClient.nuixscript`
 - Copy the folder `JavaScript\RelativityClient.nuixscript` to the Nuix Scripts folder
 
 ### Running the User Interface
@@ -136,9 +134,9 @@ Both modules call the **C# Relativity Loadfile Upload Client** which is built us
 - Copy contents of `C#\Clients` to `JavaScript\RelativityClient.nuixscript\RelativityLoadfileUpload\Clients`
 - Download and install the [Java Development Kit](https://www.oracle.com/technetwork/java/javase/downloads/index.html)
 - Download and install [Apache Maven](https://maven.apache.org/download.cgi)
-- The Maven `pom.xml` file for the Java User Interface references Nuix Workstation 8.0.3.121. If using a different version of Nuix Workstation when building the Java User Interface, modify the file `Java\RelativityClientUserInterface\pom.xml` and update the property `scripting-version` to reflect the version of Nuix Workstation installed.
-- In the `Java\RelativityClientUserInterface` folder from this repository, build the Java User Interface by running the command `mvn package`.
-- Copy the resulting file `Java\RelativityClientUserInterface\target\relativity-client-1.0.jar` to `JavaScript\RelativityClient.nuixscript`
+- The Maven `pom.xml` file for the Java User Interface references Nuix Workstation 8.6.2.414. If using a different version of Nuix Workstation when building the Java User Interface, modify the file `Java\RelativityClient\pom.xml` and update the property `scripting-version` to reflect the version of Nuix Workstation installed.
+- In the `Java\RelativityClient` folder from this repository, build the Java User Interface by running the command `mvn package`.
+- Copy the resulting file `Java\RelativityClient\target\relativity-client-1.0.jar` to `JavaScript\RelativityClient.nuixscript`
 - Copy the folder `JavaScript\RelativityClient.nuixscript` to the Nuix Scripts folder
 
 ### Running the User Interface
@@ -215,7 +213,7 @@ See below sample scriptRequest body:
 # License
 
 ```
-Copyright 2019 Nuix
+Copyright 2020 Nuix
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update to use log4j2 due to

[CVE-2019-17571](https://github.com/advisories/GHSA-2qrg-x229-3v8q)